### PR TITLE
Make usable with any mir-algorithm version >= 0.4.10 and < 0.9.0

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -3,7 +3,7 @@
 	"authors": [
 		"Ilya Yaroshenko"
 	],
-	"dependencies": {"mir-algorithm": "~>0.6.0"},
+	"dependencies": {"mir-algorithm": ">=0.4.10 <0.9.0"},
 	"description": "CPU characteristics identification",
 	"copyright": "Ilya Yaroshenko",
 	"license": "BSL-1.0",


### PR DESCRIPTION
The only thing mir-cpuid needs is [mir.bitmanip: bitfields](https://github.com/libmir/mir-algorithm/blob/master/source/mir/bitmanip.d) which was added in 0.4.10