### PR TITLE
Fix buffer overflow if mir_cpuid_init() is invoked multiple times

### DIFF
--- a/source/cpuid/unified.d
+++ b/source/cpuid/unified.d
@@ -101,6 +101,9 @@ void mir_cpuid_init()
     static if (__VERSION__ >= 2068)
         pragma(inline, false);
 
+    if (_cpus)
+        return; // already initialized
+
     import cpuid.x86_any;
 
     mir_cpuid_x86_any_init();
@@ -337,6 +340,11 @@ void mir_cpuid_init()
 /// ditto
 
 alias cpuid_init = mir_cpuid_init;
+
+unittest // make sure a 2nd invocation after the implicit CRT constructor doesn't throw
+{
+    mir_cpuid_init();
+}
 
 pure @trusted:
 


### PR DESCRIPTION
According to the comment, it should be safe to call multiple times, but e.g. the added unittest fails on my box (`_uCache_length` is incremented and not reset).

At work, this occurs when mir-cpuid is linked statically into multiple D binaries of some process - the CRT constructors share the same global state on Linux (`_uCache_length` etc. - uniqued dynamic symbols).